### PR TITLE
Expand the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Google integration in Nextcloud
 
 🇬 Google integration allows you to automatically import your Google calendars, contacts, photos and files into Nextcloud.
+
+## 🚀 Installation
+
+In your Nextcloud, simply enable the Google Integration app through the Apps management. The Google Integration app is only included in Nextcloud v20 and higher.
+
+## 🔧 Setup
+
+The app needs some setup in the Google API Console in order to work. To do this, go to Settings > Administration > Connected accounts and follow the instructions under "Google integration".


### PR DESCRIPTION
In particular, add a note that setup instructions are in the app itself, since they're kind of deemphasized in the UI. This confused me for a moment when I didn't notice them, went looking for instructions in the README instead, and found nothing.

Installation instructions shamelessly cribbed from nextcloud/photos.