### PR TITLE
Fix typo in changelog for 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - export google docs to files instead of just ignoring them
 [#21](https://github.com/nextcloud/integration_google/issues/21) @oncletom
-- void loading entire downloaded files in memory, use temp file and chunk copy
+- avoid loading entire downloaded files in memory, use temp file and chunk copy
 [#22](https://github.com/nextcloud/integration_google/issues/22) @oncletom
 
 ## 0.0.11 – 2020-10-31


### PR DESCRIPTION
While version 0.0.12 is already released, my inner OCD just doesn't like this typo, so at least people reading older changelog entries can now enjoy a proper<sup>1</sup> "avoid" :-)
<sub><sub><sup><sub>1</sup> Okay, personally this still would not be "proper" since I would start it with a capital letter, but doing that for "Avoid" would then be inconsistent with the rest.</sub></sub></sub>