### PR TITLE
added shared drives option

### DIFF
--- a/lib/Service/GoogleDriveAPIService.php
+++ b/lib/Service/GoogleDriveAPIService.php
@@ -55,6 +55,7 @@ class GoogleDriveAPIService {
 	 */
 	public function getDriveSize(string $accessToken, string $userId): array {
 		$considerSharedFiles = $this->config->getUserValue($userId, Application::APP_ID, 'consider_shared_files', '0') === '1';
+		$considerSharedDrives = $this->config->getUserValue($userId, Application::APP_ID, 'consider_shared_drives', '0') === '1';
 		$params = [
 			'fields' => '*',
 		];
@@ -73,6 +74,11 @@ class GoogleDriveAPIService {
 			'pageSize' => 1000,
 			'q' => "mimeType!='application/vnd.google-apps.folder'",
 		];
+		if ($considerSharedDrives) {
+			$params['corpora'] = 'allDrives';
+			$params['includeItemsFromAllDrives'] = 'true';
+			$params['supportsAllDrives'] = 'true';
+		}
 		if ($considerSharedFiles) {
 			$params['fields'] = 'files/name,files/ownedByMe,files/size';
 		}
@@ -195,6 +201,7 @@ class GoogleDriveAPIService {
 	public function importFiles(string $accessToken, string $userId, string $targetPath,
 								?int $maxDownloadSize = null, int $alreadyImported, array &$directoryProgress): array {
 		$considerSharedFiles = $this->config->getUserValue($userId, Application::APP_ID, 'consider_shared_files', '0') === '1';
+		$considerSharedDrives = $this->config->getUserValue($userId, Application::APP_ID, 'consider_shared_drives', '0') === '1';
 		// create root folder
 		$userFolder = $this->root->getUserFolder($userId);
 		if (!$userFolder->nodeExists($targetPath)) {
@@ -213,6 +220,11 @@ class GoogleDriveAPIService {
 			'fields' => '*',
 			'q' => "mimeType='application/vnd.google-apps.folder'",
 		];
+		if ($considerSharedDrives) {
+			$params['corpora'] = 'allDrives';
+			$params['includeItemsFromAllDrives'] = 'true';
+			$params['supportsAllDrives'] = 'true';
+		}
 		do {
 			$result = $this->googleApiService->request($accessToken, $userId, 'drive/v3/files', $params);
 			if (isset($result['error'])) {

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -51,6 +51,7 @@ class Personal implements ISettings {
 		$photoOutputDir = $this->config->getUserValue($this->userId, Application::APP_ID, 'photo_output_dir', '/Google Photos');
 		$photoOutputDir = $photoOutputDir ?: '/Google Photos';
 		$considerSharedFiles = $this->config->getUserValue($this->userId, Application::APP_ID, 'consider_shared_files', '0') === '1';
+		$considerSharedDrives = $this->config->getUserValue($this->userId, Application::APP_ID, 'consider_shared_drives', '0') === '1';
 		$considerSharedAlbums = $this->config->getUserValue($this->userId, Application::APP_ID, 'consider_shared_albums', '0') === '1';
 		$documentFormat = $this->config->getUserValue($this->userId, Application::APP_ID, 'document_format', 'openxml');
 		if (!in_array($documentFormat, ['openxml', 'opendoc'])) {
@@ -73,6 +74,7 @@ class Personal implements ISettings {
 			'free_space' => $freeSpace,
 			'user_quota' => $user->getQuota(),
 			'consider_shared_files' => $considerSharedFiles,
+			'consider_shared_drives' => $considerSharedDrives,
 			'consider_shared_albums' => $considerSharedAlbums,
 			'document_format' => $documentFormat,
 			'drive_output_dir' => $driveOutputDir,

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -152,11 +152,19 @@
 					<h3>{{ t('integration_google', 'Drive') }}</h3>
 					<div v-if="!importingDrive" class="check-option">
 						<input
+							id="consider-shared-drives"
+							type="checkbox"
+							class="checkbox"
+							:checked="!state.consider_shared_drives"
+							@input="onDriveConsiderSharedDrivesChange">
+						<label for="consider-shared-drives">{{ t('integration_google', 'Ignore shared drives') }}</label>
+						<br>
+						<input
 							id="consider-shared-files"
 							type="checkbox"
 							class="checkbox"
 							:checked="!state.consider_shared_files"
-							@input="onDriveConsiderSharedChange">
+							@input="onDriveConsiderSharedFilesChange">
 						<label for="consider-shared-files">{{ t('integration_google', 'Ignore shared files') }}</label>
 						<br>
 					</div>
@@ -192,7 +200,7 @@
 						<br><br>
 					</div>
 					<div class="line">
-						<label v-if="state.consider_shared_files && sharedWithMeSize > 0">
+						<label v-if="state.consider_shared_drives || (state.consider_shared_files && sharedWithMeSize > 0)">
 							<span class="icon icon-folder" />
 							{{ n('integration_google',
 								'{nbFiles} file in Google Drive ({formSize} + {formSharedSize} shared with you)',
@@ -724,7 +732,11 @@ export default {
 		myHumanFileSize(bytes, approx = false, si = false, dp = 1) {
 			return humanFileSize(bytes, approx, si, dp)
 		},
-		onDriveConsiderSharedChange(e) {
+		onDriveConsiderSharedDrivesChange(e) {
+			this.state.consider_shared_drives = !e.target.checked
+			this.saveOptions({ consider_shared_drives: this.state.consider_shared_drives ? '1' : '0' }, this.getGoogleDriveInfo)
+		},
+		onDriveConsiderSharedFilesChange(e) {
 			this.state.consider_shared_files = !e.target.checked
 			this.saveOptions({ consider_shared_files: this.state.consider_shared_files ? '1' : '0' }, this.getGoogleDriveInfo)
 		},


### PR DESCRIPTION
Signed-off-by: Massimiliano Calandrelli <max@maxcalandrelli.it>

I needed to synchronize files in a shared drive and I discovered they were not supported. I added minimal support for this scenario to v1.0.2. Since I have too little experience with GDrive API, I preferred to introduce a separate option for that.