### PR TITLE
Unlock files explicitly, scope checks and more

### DIFF
--- a/lib/Controller/GoogleAPIController.php
+++ b/lib/Controller/GoogleAPIController.php
@@ -114,7 +114,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googlePhotosAPIService->getPhotoNumber($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], 401);
+			$response = new DataResponse($result['error'], $result['statusCode']);
 		} else {
 			$response = new DataResponse($result);
 		}
@@ -132,7 +132,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googleContactsAPIService->getContactNumber($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], 401);
+			$response = new DataResponse($result['error'], $result['statusCode']);
 		} else {
 			$response = new DataResponse($result);
 		}
@@ -150,7 +150,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googleCalendarAPIService->getCalendarList($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], 401);
+			$response = new DataResponse($result['error'], $result['statusCode']);
 		} else {
 			$response = new DataResponse($result);
 		}
@@ -168,7 +168,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googleDriveAPIService->getDriveSize($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], 401);
+			$response = new DataResponse($result['error'], $result['statusCode']);
 		} else {
 			$response = new DataResponse($result);
 		}

--- a/lib/Controller/GoogleAPIController.php
+++ b/lib/Controller/GoogleAPIController.php
@@ -114,7 +114,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googlePhotosAPIService->getPhotoNumber($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], $result['statusCode']);
+			$response = new DataResponse($result['error'], 401);
 		} else {
 			$response = new DataResponse($result);
 		}
@@ -132,7 +132,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googleContactsAPIService->getContactNumber($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], $result['statusCode']);
+			$response = new DataResponse($result['error'], 401);
 		} else {
 			$response = new DataResponse($result);
 		}
@@ -150,7 +150,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googleCalendarAPIService->getCalendarList($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], $result['statusCode']);
+			$response = new DataResponse($result['error'], 401);
 		} else {
 			$response = new DataResponse($result);
 		}
@@ -168,7 +168,7 @@ class GoogleAPIController extends Controller {
 		}
 		$result = $this->googleDriveAPIService->getDriveSize($this->accessToken, $this->userId);
 		if (isset($result['error'])) {
-			$response = new DataResponse($result['error'], $result['statusCode']);
+			$response = new DataResponse($result['error'], 401);
 		} else {
 			$response = new DataResponse($result);
 		}

--- a/lib/Service/GoogleAPIService.php
+++ b/lib/Service/GoogleAPIService.php
@@ -159,7 +159,7 @@ class GoogleAPIService {
 					'Google API request 400 FAILURE, method '.$method.', URL: ' . $url . ' , body: ' . $body,
 					['app' => $this->appName]
 				);
-				return ['error' => 'Bad credentials'];
+				return ['error' => 'Bad credentials', 'statusCode' => $respCode];
 			} else {
 				$this->logger->info(
 					'Google API request SUCCESS: , method ' . $method . ', URL: ' . $url
@@ -184,7 +184,7 @@ class GoogleAPIService {
 						$result['access_token'], $userId, $endPoint, $params, $method, $baseUrl
 					);
 				}
-				return ['error' => 'Impossible to refresh the token'];
+				return ['error' => 'Impossible to refresh the token', 'statusCode' => 401];
 			}
 			$this->logger->warning(
 				'Google API ServerException|ClientException error : '.$e->getMessage()
@@ -194,8 +194,8 @@ class GoogleAPIService {
 			);
 			return [
 				'error' => 'ServerException|ClientException, message:'
-					. $e->getMessage()
-					. ' status code: ' . $response->getStatusCode()
+					. $e->getMessage(),
+				'statusCode' => $response->getStatusCode()
 			];
 		} catch (ConnectException $e) {
 			$this->logger->warning('Google API error : '.$e->getMessage(), ['app' => $this->appName]);

--- a/lib/Service/GoogleAPIService.php
+++ b/lib/Service/GoogleAPIService.php
@@ -69,6 +69,22 @@ class GoogleAPIService {
 	}
 
 	/**
+	 * @param string $baseUrl
+	 * @param array $params
+	 * @return string
+	 */
+	private function buildURL(string $baseUrl, array $params = []): string {
+		$paramsContent = http_build_query($params);
+		if (strpos($baseUrl, '?') !== FALSE) {
+        	$baseUrl .= '&'. $paramsContent;
+        }
+        else {
+			$baseUrl .= '?' . $paramsContent;
+		}
+		return $baseUrl;
+
+	}
+	/**
 	 * @param string $userId
 	 * @param string $subject
 	 * @param array $params
@@ -112,8 +128,7 @@ class GoogleAPIService {
 
 			if (count($params) > 0) {
 				if ($method === 'GET') {
-					$paramsContent = http_build_query($params);
-					$url .= '?' . $paramsContent;
+					$url = $this->buildURL($url, $params);
 				} else {
 					$options['body'] = json_encode($params);
 				}
@@ -205,8 +220,7 @@ class GoogleAPIService {
 
 			if (count($params) > 0) {
 				if ($method === 'GET') {
-					$paramsContent = http_build_query($params);
-					$url .= '?' . $paramsContent;
+					$url = $this->buildURL($url, $params);
 				} else {
 					$options['body'] = $params;
 				}
@@ -258,8 +272,7 @@ class GoogleAPIService {
 
 			if (count($params) > 0) {
 				if ($method === 'GET') {
-					$paramsContent = http_build_query($params);
-					$url .= '?' . $paramsContent;
+					$url = $this->buildURL($url, $params);
 				} else {
 					$options['body'] = json_encode($params);
 				}
@@ -330,8 +343,7 @@ class GoogleAPIService {
 
 			if (count($params) > 0) {
 				if ($method === 'GET') {
-					$paramsContent = http_build_query($params);
-					$url .= '?' . $paramsContent;
+					$url = $this->buildURL($url, $params);
 				} else {
 					$options['body'] = json_encode($params);
 				}

--- a/lib/Service/GoogleAPIService.php
+++ b/lib/Service/GoogleAPIService.php
@@ -159,7 +159,7 @@ class GoogleAPIService {
 					'Google API request 400 FAILURE, method '.$method.', URL: ' . $url . ' , body: ' . $body,
 					['app' => $this->appName]
 				);
-				return ['error' => 'Bad credentials', 'statusCode' => $respCode];
+				return ['error' => 'Bad credentials'];
 			} else {
 				$this->logger->info(
 					'Google API request SUCCESS: , method ' . $method . ', URL: ' . $url
@@ -184,7 +184,7 @@ class GoogleAPIService {
 						$result['access_token'], $userId, $endPoint, $params, $method, $baseUrl
 					);
 				}
-				return ['error' => 'Impossible to refresh the token', 'statusCode' => 401];
+				return ['error' => 'Impossible to refresh the token'];
 			}
 			$this->logger->warning(
 				'Google API ServerException|ClientException error : '.$e->getMessage()
@@ -194,8 +194,8 @@ class GoogleAPIService {
 			);
 			return [
 				'error' => 'ServerException|ClientException, message:'
-					. $e->getMessage(),
-				'statusCode' => $response->getStatusCode()
+					. $e->getMessage()
+					. ' status code: ' . $response->getStatusCode(),
 			];
 		} catch (ConnectException $e) {
 			$this->logger->warning('Google API error : '.$e->getMessage(), ['app' => $this->appName]);

--- a/lib/Service/GoogleDriveAPIService.php
+++ b/lib/Service/GoogleDriveAPIService.php
@@ -432,6 +432,7 @@ class GoogleDriveAPIService {
 				} else {
 					$this->logger->warning('Google Drive error downloading file ' . $fileItem['name'] . ' : ' . $res['error'], ['app' => $this->appName]);
 					if ($savedFile->isDeletable()) {
+						$savedFile->unlock(\OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 						$savedFile->delete();
 					}
 				}
@@ -503,6 +504,7 @@ class GoogleDriveAPIService {
 				} else {
 					$this->logger->warning('Google Drive error downloading file ' . $fileItem['name'] . ' : ' . $res['error'], ['app' => $this->appName]);
 					if ($savedFile->isDeletable()) {
+						$savedFile->unlock(\OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 						$savedFile->delete();
 					}
 				}

--- a/lib/Service/GooglePhotosAPIService.php
+++ b/lib/Service/GooglePhotosAPIService.php
@@ -95,13 +95,7 @@ class GooglePhotosAPIService {
 				foreach ($result['albums'] as $album) {
 					$nbPhotos += $album['mediaItemsCount'] ?? 0;
 				}
-			} else {
-				$this->logger->warning(
-					'Google API error getting album list to get photo number, no "albums" key in '
-						. json_encode($result),
-					['app' => $this->appName]
-				);
-			}
+			} 
 			$params['pageToken'] = $result['nextPageToken'] ?? '';
 		} while (isset($result['nextPageToken']));
 
@@ -120,13 +114,7 @@ class GooglePhotosAPIService {
 					foreach ($result['sharedAlbums'] as $album) {
 						$nbPhotos += $album['mediaItemsCount'] ?? 0;
 					}
-				} else {
-					$this->logger->warning(
-						'Google API error getting shared albums list to get photo number, no "sharedAlbums" key in '
-							. json_encode($result),
-						['app' => $this->appName]
-					);
-				}
+				} 
 				$params['pageToken'] = $result['nextPageToken'] ?? '';
 			} while (isset($result['nextPageToken']));
 		}
@@ -250,13 +238,7 @@ class GooglePhotosAPIService {
 				foreach ($result['albums'] as $album) {
 					$albums[] = $album;
 				}
-			} else {
-				$this->logger->warning(
-					'Google API error getting album list when importing, no "albums" key in '
-						. json_encode($result),
-					['app' => $this->appName]
-				);
-			}
+			} 
 			$params['pageToken'] = $result['nextPageToken'] ?? '';
 		} while (isset($result['nextPageToken']));
 
@@ -275,8 +257,6 @@ class GooglePhotosAPIService {
 					foreach ($result['sharedAlbums'] as $album) {
 						$albums[] = $album;
 					}
-				} else {
-					$this->logger->warning('Google API error getting shared albums list, no "sharedAlbums" key in ' . json_encode($result), ['app' => $this->appName]);
 				}
 				$params['pageToken'] = $result['nextPageToken'] ?? '';
 			} while (isset($result['nextPageToken']));
@@ -331,9 +311,7 @@ class GooglePhotosAPIService {
 							}
 						}
 					}
-				} else {
-					$this->logger->warning('Google API error getting photo list, no "mediaItems" key in ' . json_encode($result), ['app' => $this->appName]);
-				}
+				} 
 				$params['pageToken'] = $result['nextPageToken'] ?? '';
 			} while (isset($result['nextPageToken']));
 		}
@@ -368,9 +346,7 @@ class GooglePhotosAPIService {
 						}
 					}
 				}
-			} else {
-				$this->logger->warning('Google API error getting photo list, no "mediaItems" key in ' . json_encode($result), ['app' => $this->appName]);
-			}
+			} 
 			$params['pageToken'] = $result['nextPageToken'] ?? '';
 		} while (isset($result['nextPageToken']));
 
@@ -409,7 +385,6 @@ class GooglePhotosAPIService {
 			try {
 				$resource = $savedFile->fopen('w');
 			} catch (LockedException $e) {
-				$this->logger->warning('Google Photo, error opening target file ' . $savedFile->getPath() . ' : file is locked', ['app' => $this->appName]);
 				return null;
 			}
 			$res = $this->googleApiService->simpleDownload($accessToken, $userId, $photoUrl, $resource);
@@ -427,7 +402,6 @@ class GooglePhotosAPIService {
 				$stat = $savedFile->stat();
 				return $stat['size'] ?? 0;
 			} else {
-				$this->logger->warning('Google API error downloading photo ' . $photoName . ' : ' . $res['error'], ['app' => $this->appName]);
 				if ($savedFile->isDeletable()) {
 					$savedFile->unlock(\OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 					$savedFile->delete();

--- a/lib/Service/GooglePhotosAPIService.php
+++ b/lib/Service/GooglePhotosAPIService.php
@@ -429,6 +429,7 @@ class GooglePhotosAPIService {
 			} else {
 				$this->logger->warning('Google API error downloading photo ' . $photoName . ' : ' . $res['error'], ['app' => $this->appName]);
 				if ($savedFile->isDeletable()) {
+					$savedFile->unlock(\OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 					$savedFile->delete();
 				}
 			}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -84,6 +84,10 @@ class Personal implements ISettings {
 			$info = $this->googleAPIService->request($accessToken, $this->userId, 'oauth2/v1/userinfo', ['alt' => 'json']);
 		}
 
+		// Get scopes of user
+		$userScopes = $this->config->getUserValue($this->userId, Application::APP_ID, 'user_scopes', '{}');
+		$userScopes = json_decode($userScopes);
+
 		$userConfig = [
 			'client_id' => $clientID,
 			'client_secret' => $clientSecret,
@@ -95,6 +99,7 @@ class Personal implements ISettings {
 			'document_format' => $documentFormat,
 			'drive_output_dir' => $driveOutputDir,
 			'photo_output_dir' => $photoOutputDir,
+			'user_scopes' => $userScopes,
 		];
 		$this->initialStateService->provideInitialState('user-config', $userConfig);
 		return new TemplateResponse(Application::APP_ID, 'personalSettings');

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -354,13 +354,21 @@ export default {
 
 		// get informations if we are connected
 		if (this.showOAuth && this.connected) {
-			this.getGoogleCalendarList()
-			this.getLocalAddressBooks()
-			this.getNbGoogleContacts()
-			this.getNbGooglePhotos()
-			this.getPhotoImportValues(true)
-			this.getGoogleDriveInfo()
-			this.getDriveImportValues(true)
+			if (this.state.user_scopes.can_access_calendar) {
+				this.getGoogleCalendarList()
+				this.getLocalAddressBooks()
+			}
+			if (this.state.user_scopes.can_access_contacts) {
+				this.getNbGoogleContacts()
+			}
+			if (this.state.user_scopes.can_access_photos) {
+				this.getNbGooglePhotos()
+				this.getPhotoImportValues(true)
+			}
+			if (this.state.user_scopes.can_access_drive) {
+				this.getGoogleDriveInfo()
+				this.getDriveImportValues(true)
+			}
 		}
 	},
 
@@ -443,13 +451,10 @@ export default {
 					}
 				})
 				.catch((error) => {
-					// Ignore 403s as it could mean that the user hasn't given permissions
-					if (error.response.status !== 403) {
-						showError(
-							t('integration_google', 'Failed to get Google Drive information')
-							+ ': ' + error.response?.request?.responseText
-						)
-					}
+					showError(
+						t('integration_google', 'Failed to get Google Drive information')
+						+ ': ' + error.response?.request?.responseText
+					)
 				})
 				.then(() => {
 					this.gettingDriveInfo = false
@@ -464,13 +469,10 @@ export default {
 					}
 				})
 				.catch((error) => {
-					// Ignore 403s as it could mean that the user hasn't given permissions
-					if (error.response.status !== 403) {
-						showError(
-							t('integration_google', 'Failed to get calendar list')
-							+ ': ' + error.response?.request?.responseText
-						)
-					}
+					showError(
+						t('integration_google', 'Failed to get calendar list')
+						+ ': ' + error.response?.request?.responseText
+					)
 				})
 				.then(() => {
 				})
@@ -515,13 +517,10 @@ export default {
 					}
 				})
 				.catch((error) => {
-					// Ignore 403s as it could mean that the user hasn't given permissions
-					if (error.response.status !== 403) {
-						showError(
-							t('integration_google', 'Failed to get number of Google photos')
-							+ ': ' + error.response?.request?.responseText
-						)
-					}
+					showError(
+						t('integration_google', 'Failed to get number of Google photos')
+						+ ': ' + error.response?.request?.responseText
+					)
 				})
 				.then(() => {
 					this.gettingPhotoInfo = false
@@ -536,13 +535,10 @@ export default {
 					}
 				})
 				.catch((error) => {
-					// Ignore 403s as it could mean that the user hasn't given permissions
-					if (error.response.status !== 403) {
-						showError(
-							t('integration_google', 'Failed to get number of Google contacts')
-							+ ': ' + error.response?.request?.responseText
-						)
-					}
+					showError(
+						t('integration_google', 'Failed to get number of Google contacts')
+						+ ': ' + error.response?.request?.responseText
+					)
 				})
 				.then(() => {
 				})

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -443,10 +443,13 @@ export default {
 					}
 				})
 				.catch((error) => {
-					showError(
-						t('integration_google', 'Failed to get Google Drive information')
-						+ ': ' + error.response?.request?.responseText
-					)
+					// Ignore 403s as it could mean that the user hasn't given permissions
+					if (error.response.status !== 403) {
+						showError(
+							t('integration_google', 'Failed to get Google Drive information')
+							+ ': ' + error.response?.request?.responseText
+						)
+					}
 				})
 				.then(() => {
 					this.gettingDriveInfo = false
@@ -461,10 +464,13 @@ export default {
 					}
 				})
 				.catch((error) => {
-					showError(
-						t('integration_google', 'Failed to get calendar list')
-						+ ': ' + error.response?.request?.responseText
-					)
+					// Ignore 403s as it could mean that the user hasn't given permissions
+					if (error.response.status !== 403) {
+						showError(
+							t('integration_google', 'Failed to get calendar list')
+							+ ': ' + error.response?.request?.responseText
+						)
+					}
 				})
 				.then(() => {
 				})
@@ -509,10 +515,13 @@ export default {
 					}
 				})
 				.catch((error) => {
-					showError(
-						t('integration_google', 'Failed to get number of Google photos')
-						+ ': ' + error.response?.request?.responseText
-					)
+					// Ignore 403s as it could mean that the user hasn't given permissions
+					if (error.response.status !== 403) {
+						showError(
+							t('integration_google', 'Failed to get number of Google photos')
+							+ ': ' + error.response?.request?.responseText
+						)
+					}
 				})
 				.then(() => {
 					this.gettingPhotoInfo = false
@@ -527,10 +536,13 @@ export default {
 					}
 				})
 				.catch((error) => {
-					showError(
-						t('integration_google', 'Failed to get number of Google contacts')
-						+ ': ' + error.response?.request?.responseText
-					)
+					// Ignore 403s as it could mean that the user hasn't given permissions
+					if (error.response.status !== 403) {
+						showError(
+							t('integration_google', 'Failed to get number of Google contacts')
+							+ ': ' + error.response?.request?.responseText
+						)
+					}
 				})
 				.then(() => {
 				})


### PR DESCRIPTION
This PR contains a bunch of different fixes to the app:

1) When a file is not downloaded from the Google Drive API for some reason(sometimes we have 403 forbidden responses), the files has to be deleted. 
  - During deletion, we see this error that causes the entire import to fail: `Google Drive import error: Unknow job failure. "File" is locked, existing lock on file: exclusive`
  - In the changes here, the file is explicitly unlocked before deletion so as to not cause issues with importing other files in the user's drive.

2) Scope checks from oauth redirect:
  - The scopes available to the access token are returned by the oauth redirect but they are not used currently
  - In the changes here, we are storing these scopes and using them to allow the user to import things accordingly
    - For example, if the user doesn't permit permissions to view and download photos, the "Import Photos" button is not displayed
    - Closes https://github.com/nextcloud/integration_google/issues/79

3) Google Drive allows files to have the same file name but Nextcloud doesn't. In order to ensure that files of the same also get downloaded(while maintaining a mapping between a file that has been imported and a file that is on Google Drive), we append the last 6 characters of the `fileItem` ID to the file name.
  - If the file with given file name already exists in the target directory of import, we check if the modified timestamp has changed and download it again from Google Drive if it has changed. This allows for resynch behavior

4) Many logger warnings have been removed as they contain information about the user's files and their metadata and this is a privacy concern. 

5) A new file called `failed-downloads.md` is created for Drive  imports in the user's chosen import directory. This contains a list of the files that failed to download for whatever reason.