### PR TITLE
Fix for not being able to import photos when user has no albums

### DIFF
--- a/lib/Service/GooglePhotosAPIService.php
+++ b/lib/Service/GooglePhotosAPIService.php
@@ -130,6 +130,30 @@ class GooglePhotosAPIService {
 				$params['pageToken'] = $result['nextPageToken'] ?? '';
 			} while (isset($result['nextPageToken']));
 		}
+
+		if (!($nbPhotos > 0)) {
+
+			$params = [
+				'pageSize' => 50,
+			];
+
+			$result = $this->googleApiService->request($accessToken, $userId, 'v1/mediaItems', $params, 'GET', 'https://photoslibrary.googleapis.com/');
+            if (isset($result['error'])) {
+                return $result;
+			}
+			  
+			if(isset($result['mediaItems']) && is_array($result['mediaItems'])) {
+                $nbPhotos += count($result['mediaItems']);
+			}
+			else {
+				$this->logger->warning(
+					'Google API error getting media items list to get photo number, no "mediaItems" key in '
+						. json_encode($result),
+					['app' => $this->appName]
+				);
+			}
+		}
+		
 		return [
 			'nbPhotos' => $nbPhotos,
 		];

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -113,15 +113,6 @@
 						<br><br>
 					</div>
 					<div class="line">
-						<label>
-							<span class="icon icon-toggle-pictures" />
-							{{ n('integration_google',
-								'~{nbPhotos} Google photo (~{formSize})',
-								'~{nbPhotos} Google photos (~{formSize})',
-								nbPhotos,
-								{ nbPhotos, formSize: myHumanFileSize(estimatedPhotoCollectionSize, true) })
-							}}
-						</label>
 						<button v-if="enoughSpaceForPhotos && !importingPhotos"
 							id="google-import-photos"
 							:disabled="gettingPhotoInfo"


### PR DESCRIPTION
- The current changes add an API call to check if any photos exist in library apart from the ones in albums
- Closes https://github.com/nextcloud/integration_google/issues/80
- However, the number of photos available to import  is no longer displayed
  - This is not going to be accurate anyway as we do only one API call to check for photos in library that are not in albums
  - To get accurate results for number of photos, we will have to go through all the photos in the user's library with a maximum of 100 photos per request
  - These API calls have to happen again while downloading photos
  - By trying to get an accurate number of photos in the user's account,  we exhaust the rate limit for Google Photos very quickly
  - Therefore, the number of photos available to import is no longer displayed but instead the button is displayed if this is a number greater than 0