### PR TITLE
Urlencoded calendar ids and fileItem ids

### DIFF
--- a/lib/Service/GoogleCalendarAPIService.php
+++ b/lib/Service/GoogleCalendarAPIService.php
@@ -295,7 +295,7 @@ class GoogleCalendarAPIService {
 			'maxResults' => 100,
 		];
 		do {
-			$result = $this->googleApiService->request($accessToken, $userId, 'calendar/v3/calendars/'.$calId.'/events', $params);
+			$result = $this->googleApiService->request($accessToken, $userId, 'calendar/v3/calendars/'. urlencode($calId) .'/events', $params);
 			if (isset($result['error'])) {
 				return $result;
 			}

--- a/lib/Service/GoogleDriveAPIService.php
+++ b/lib/Service/GoogleDriveAPIService.php
@@ -567,11 +567,11 @@ class GoogleDriveAPIService {
 			$documentFormat = $this->getUserDocumentFormat($userId);
 			// potentially a doc
 			$params = $this->getDocumentRequestParams($fileItem['mimeType'], $documentFormat);
-			$fileUrl = 'https://www.googleapis.com/drive/v3/files/' . $fileItem['id'] . '/export';
+			$fileUrl = 'https://www.googleapis.com/drive/v3/files/' . urlencode($fileItem['id']) . '/export';
 			return $this->downloadAndSaveFile($accessToken, $saveFolder, $fileName, $userId, $fileUrl, $fileItem, $params);
 		} elseif (isset($fileItem['webContentLink'])) {
 			// classic file
-			$fileUrl = 'https://www.googleapis.com/drive/v3/files/' . $fileItem['id'] . '?alt=media';
+			$fileUrl = 'https://www.googleapis.com/drive/v3/files/' . urlencode($fileItem['id']) . '?alt=media';
 			return $this->downloadAndSaveFile($accessToken, $saveFolder, $fileName, $userId, $fileUrl, $fileItem);
 		}
 		return null;


### PR DESCRIPTION
- Need to `urlencode` calendar IDs for public calendars as they contain hashtag and '@' characters
- These characters in the request URL cause 404s when they are not urlencoded and therefore public calendars cannot be downloaded
- This PR fixes this problem by encoding the calendar IDs and the fileItem IDs in the urls before requesting