### PR TITLE
Corrected "connected as {user}" string for ca.js

### DIFF
--- a/l10n/ca.js
+++ b/l10n/ca.js
@@ -33,7 +33,7 @@ OC.L10N.register(
     "Google data migration" : "Migració de dades de Google",
     "No Google OAuth app configured. Ask your Nextcloud administrator to configure Google connected accounts admin section." : "No s'ha configurat cap aplicació Google OAuth. Demaneu a l'administrador de Nextcloud que configuri la secció d'administració de comptes connectades a Google.",
     "Authentication" : "Autenticació",
-    "Connected as {user}" : "S'ha connectat com a {usuari}",
+    "Connected as {user}" : "S'ha connectat com a {user}",
     "Disconnect from Google" : "Desconnectar-se de Google",
     "Contacts" : "Contactes",
     "{amount} Google contacts" : "{amount} Contactes de Google",

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -31,7 +31,7 @@
     "Google data migration" : "Migració de dades de Google",
     "No Google OAuth app configured. Ask your Nextcloud administrator to configure Google connected accounts admin section." : "No s'ha configurat cap aplicació Google OAuth. Demaneu a l'administrador de Nextcloud que configuri la secció d'administració de comptes connectades a Google.",
     "Authentication" : "Autenticació",
-    "Connected as {user}" : "S'ha connectat com a {usuari}",
+    "Connected as {user}" : "S'ha connectat com a {user}",
     "Disconnect from Google" : "Desconnectar-se de Google",
     "Contacts" : "Contactes",
     "{amount} Google contacts" : "{amount} Contactes de Google",


### PR DESCRIPTION
- The variable placeholder was wrong(fixed in this PR) and led to a screen like:
![image](https://user-images.githubusercontent.com/14362579/144822562-fcce40f8-6217-4a70-9441-255dadba7dd9.png)
