### PR TITLE
Fix google drive pagination and name converstion bug

### DIFF
--- a/lib/Service/GoogleDriveAPIService.php
+++ b/lib/Service/GoogleDriveAPIService.php
@@ -200,7 +200,7 @@ class GoogleDriveAPIService {
 			$result = $this->importFiles($accessToken, $userId, $targetPath, 500000000, $alreadyImported, $directoryProgress);
 		} catch (\Exception | \Throwable $e) {
 			$result = [
-				'error' => 'Unknown job failure. ' . $e->getMessage(),
+				'error' => 'Unknown job failure. ' . $e,
 			];
 		}
 		if (isset($result['error']) || (isset($result['finished']) && $result['finished'])) {
@@ -493,7 +493,7 @@ class GoogleDriveAPIService {
 	 * @return string name of the file to be saved
 	*/
 	private function getFileName(array $fileItem, string $userId): string {
-		$fileName = preg_replace('/\//', '-', $fileItem['name'] ?? 'Untitled');
+		$fileName = preg_replace('/\\n/', '', preg_replace('/\//', '-', $fileItem['name'] ?? 'Untitled'));
 
 		if (in_array($fileItem['mimeType'], array_values(self::DOCUMENT_MIME_TYPES))) {
 			$documentFormat = $this->getUserDocumentFormat($userId);

--- a/lib/Service/GoogleDriveAPIService.php
+++ b/lib/Service/GoogleDriveAPIService.php
@@ -103,12 +103,12 @@ class GoogleDriveAPIService {
 		$nbFiles = 0;
 		$sharedWithMeSize = 0;
 		$params = [
-			'fields' => 'files/name,files/ownedByMe',
+			'fields' => 'nextPageToken,files/name,files/ownedByMe',
 			'pageSize' => 1000,
 			'q' => "mimeType!='application/vnd.google-apps.folder'",
 		];
 		if ($considerSharedFiles) {
-			$params['fields'] = 'files/name,files/ownedByMe,files/size';
+			$params['fields'] = 'nextPageToken,files/name,files/ownedByMe,files/size';
 		}
 		do {
 			$result = $this->googleApiService->request($accessToken, $userId, 'drive/v3/files', $params);
@@ -306,6 +306,7 @@ class GoogleDriveAPIService {
 			$params = [
 				'pageSize' => 1000,
 				'fields' => implode(',', [
+					'nextPageToken',
 					'files/id',
 					'files/name',
 					'files/parents',


### PR DESCRIPTION
This PR fixes two things
1. It fixes pagination. Previously, the `$result['nextPageToken']` always was empty because we were not requesting `nextPageToken` via the `fields` param, so we were only ever requesting one page
2. Files containing `'\n'` would fail because nextcloud would create them and then not be able to find them again (resulting in NotFound errors).  