### PR TITLE
🐛 Corrected import photos when paths contain "/"

### DIFF
--- a/lib/Service/GooglePhotosAPIService.php
+++ b/lib/Service/GooglePhotosAPIService.php
@@ -295,7 +295,7 @@ class GooglePhotosAPIService {
 		$seenIds = [];
 		foreach ($albums as $album) {
 			$albumId = $album['id'];
-			$albumName = $album['title'] ?? 'Untitled';
+			$albumName = $album['title'] ? preg_replace('/\//', '_', $album['title']) : 'Untitled';
 			if (!$folder->nodeExists($albumName)) {
 				$albumFolder = $folder->newFolder($albumName);
 			} else {
@@ -390,7 +390,7 @@ class GooglePhotosAPIService {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	private function getPhoto(string $userId, array $photo, Folder $albumFolder): ?int {
-		$photoName = $photo['filename'];
+		$photoName = preg_replace('/\//', '_', $photo['filename']);
 		if (!$albumFolder->nodeExists($photoName)) {
 			if (isset($photo['mediaMetadata']['photo'])) {
 				$photoUrl = $photo['baseUrl']


### PR DESCRIPTION
This PR replaces "/" by _ in pictures and album names. 