### PR TITLE
Add whitespace between string and redirect URI

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -15,7 +15,7 @@
 		<br>
 		<p class="settings-hint with-icon">
 			<InformationOutlineIcon />
-			{{ t('integration_google', 'Make sure you set one "Authorized redirect URI" to') }}
+			{{ t('integration_google', 'Make sure you set one "Authorized redirect URI" to') + ' ' }}
 			<b> {{ redirect_uri }} </b>
 		</p>
 		<br>


### PR DESCRIPTION
Currently there is no whitepsace between the string and redirect URI:
<img width="1052" alt="censored2" src="https://user-images.githubusercontent.com/47790222/208151871-4d6859e5-961d-4d16-92cc-32b97b16ddc1.png">
This commit hopefully fixes that, but since I've never written a line of Vue nor did I test the change I can't verify that.