### PR TITLE
Allow partial(folder based) imports

### DIFF
--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -40,6 +40,7 @@ class Personal implements ISettings {
 		$userName = $this->config->getUserValue($this->userId, Application::APP_ID, 'user_name');
 		$driveOutputDir = $this->config->getUserValue($this->userId, Application::APP_ID, 'drive_output_dir', '/Google Drive');
 		$driveOutputDir = $driveOutputDir ?: '/Google Drive';
+		$driveRemoteRoot = $this->config->getUserValue($this->userId, Application::APP_ID, 'drive_remote_root', '');
 		$photoOutputDir = $this->config->getUserValue($this->userId, Application::APP_ID, 'photo_output_dir', '/Google Photos');
 		$photoOutputDir = $photoOutputDir ?: '/Google Photos';
 		$considerSharedFiles = $this->config->getUserValue($this->userId, Application::APP_ID, 'consider_shared_files', '0') === '1';
@@ -86,6 +87,7 @@ class Personal implements ISettings {
 			'consider_shared_albums' => $considerSharedAlbums,
 			'document_format' => $documentFormat,
 			'drive_output_dir' => $driveOutputDir,
+            'drive_remote_root' => $driveRemoteRoot,
 			'photo_output_dir' => $photoOutputDir,
 			'user_scopes' => $userScopes,
 		];

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -200,6 +200,17 @@
 						</NcButton>
 						<br><br>
 					</div>
+					<div v-if="!importingDrive" class="line">
+						<label for="document-format">
+							<FolderIcon />
+							{{ t('integration_google', 'Remote Folder ID/URL (advanced)') }}
+						</label>
+						<input id="drive-remote-folder"
+							v-model="state.drive_remote_root"
+							:placeholder="t('integration_google', 'Optional')"
+							@input="onDriveRemoteRootInput">
+						<br><br>
+					</div>
 					<div class="line">
 						<label v-if="state.consider_shared_files && sharedWithMeSize > 0">
 							<FileIcon />
@@ -272,7 +283,7 @@ import { showSuccess, showError } from '@nextcloud/dialogs'
 import NcAppNavigationIconBullet from '@nextcloud/vue/dist/Components/NcAppNavigationIconBullet.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import { humanFileSize } from '../utils.js'
+import { delay, humanFileSize } from '../utils.js'
 
 export default {
 	name: 'PersonalSettings',
@@ -768,6 +779,10 @@ export default {
 				})
 		},
 		onImportDrive() {
+			// ensure that drive_remote_root is saved
+			this.saveOptions({
+				drive_remote_root: this.state.drive_remote_root,
+			})
 			const req = {
 				params: {
 				},
@@ -840,6 +855,14 @@ export default {
 				true
 			)
 		},
+		onDriveRemoteRootInput() {
+			const that = this
+			delay(() => {
+				that.saveOptions({
+					drive_remote_root: this.state.drive_remote_root,
+				})
+			}, 1000)()
+		},
 		onPhotoOutputChange() {
 			OC.dialogs.filepicker(
 				t('integration_google', 'Choose where to write imported photos'),
@@ -902,6 +925,9 @@ export default {
 		&#google-import-files {
 			height: 34px;
 		}
+	}
+	#drive-remote-folder{
+		min-width: 300px;
 	}
 
 	#google-contacts {


### PR DESCRIPTION
Sometimes users just want to import one or two folders from google drive. Here is a possible solution.

A user can provide a `FolderId` or a `Folder Link` and only that folder content will be imported in this case

![image](https://github.com/nextcloud/integration_google/assets/10747559/dcc5e594-cc07-438f-b0e9-534609670531)
