### PR TITLE
calculate 'free_space' based on folder location (external storage)

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -74,6 +74,13 @@ class ConfigController extends Controller {
 			$this->config->deleteUserValue($this->userId, Application::APP_ID, 'token_expires_at');
 			$this->config->deleteUserValue($this->userId, Application::APP_ID, 'token');
 			$result['user_name'] = '';
+		}else{
+			if (isset($values['drive_output_dir'])) {
+				/** @var \OCP\Files\IRootFolder $root */
+				$root = \OC::$server->get(\OCP\Files\IRootFolder::class);
+				$userRoot = $root->getUserFolder($this->userId);
+				$result['free_space'] = \OCA\Google\Settings\Personal::getFreeSpace($userRoot, $values['drive_output_dir']);
+			}
 		}
 		return new DataResponse($result);
 	}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -56,9 +56,7 @@ class Personal implements ISettings {
 
 		// get free space
 		$userFolder = $this->root->getUserFolder($this->userId);
-		/** @var IStorage $storage */
-		$storage = $userFolder->getStorage();
-		$freeSpace = $storage->free_space('/');
+		$freeSpace = self::getFreeSpace($userFolder, $driveOutputDir);
 		$user = $this->userManager->get($this->userId);
 
 		// make a request to potentially refresh the token before the settings page is loaded
@@ -99,5 +97,15 @@ class Personal implements ISettings {
 
 	public function getPriority(): int {
 		return 10;
+	}
+
+	public static function getFreeSpace(\OCP\Files\Folder $userRoot, string $outputDir) {
+		try {
+			// OutputDir can be on an external storage which can have more free space
+			$freeSpace = $userRoot->get($outputDir)->getStorage()->free_space('/');
+		} catch (\Throwable $e) {
+			$freeSpace = false;
+		}
+		return $freeSpace !== false && $freeSpace > 0 ? $freeSpace : $userRoot->getStorage()->free_space('/');
 	}
 }

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -442,7 +442,7 @@ export default {
 					showSuccess(t('integration_google', 'Google options saved'))
 					// callback
 					if (callback) {
-						callback()
+						callback(response)
 					}
 				})
 				.catch((error) => {
@@ -833,7 +833,11 @@ export default {
 						targetPath = '/'
 					}
 					this.state.drive_output_dir = targetPath
-					this.saveOptions({ drive_output_dir: this.state.drive_output_dir })
+					this.saveOptions({ drive_output_dir: this.state.drive_output_dir }, (response) => {
+						if (response.data && response.data.free_space) {
+							this.state.free_space = response.data.free_space
+						}
+					})
 				},
 				false,
 				'httpd/unix-directory',


### PR DESCRIPTION
For example we can have a 50GB google drive and on NC side we have users personal quota of 5GB + 100GB on NFS/NAS external storage ( https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/external_storage_configuration_gui.html ) connected to `/External Storage` folder.

Currently there is no way to import 50GB drive event into the `/External Storage` folder because of '_Not enough space..._` warning. 
