### PR TITLE
feat: switch to outlined icons

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -32,7 +32,7 @@
 		<div class="fields">
 			<div class="line">
 				<label for="google-client-id">
-					<KeyIcon />
+					<KeyOutlineIcon />
 					{{ t('integration_google', 'Client ID') }}
 				</label>
 				<input id="google-client-id"
@@ -45,7 +45,7 @@
 			</div>
 			<div class="line">
 				<label for="google-client-secret">
-					<KeyIcon />
+					<KeyOutlineIcon />
 					{{ t('integration_google', 'Client secret') }}
 				</label>
 				<input id="google-client-secret"
@@ -66,7 +66,7 @@
 </template>
 
 <script>
-import KeyIcon from 'vue-material-design-icons/Key.vue'
+import KeyOutlineIcon from 'vue-material-design-icons/KeyOutline.vue'
 import InformationOutlineIcon from 'vue-material-design-icons/InformationOutline.vue'
 
 import GoogleIcon from './icons/GoogleIcon.vue'
@@ -85,7 +85,7 @@ export default {
 	components: {
 		GoogleIcon,
 		NcCheckboxRadioSwitch,
-		KeyIcon,
+		KeyOutlineIcon,
 		InformationOutlineIcon,
 	},
 

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -40,14 +40,14 @@
 					</div>
 					<div class="line">
 						<label>
-							<AccountGroupIcon />
+							<AccountGroupOutlineIcon />
 							{{ state.consider_other_contacts
 								? t('integration_google', '{amount} Google + {otherAmount} other contacts', { amount: nbContacts, otherAmount: nbOtherContacts })
 								: t('integration_google', '{amount} Google contacts', { amount: nbContacts }) }}
 						</label>
 						<NcButton @click="onImportContacts">
 							<template #icon>
-								<AccountMultipleIcon />
+								<AccountMultipleOutlineIcon />
 							</template>
 							{{ t('integration_google', 'Import Google Contacts in Nextcloud') }}
 						</NcButton>
@@ -75,7 +75,7 @@
 							:class="{ loading: importingContacts }"
 							@click="onFinalImportContacts">
 							<template #icon>
-								<DownloadIcon />
+								<DownloadOutlineIcon />
 							</template>
 							{{ t('integration_google', 'Import in "{name}" address book', { name: selectedAddressBookName }) }}
 						</NcButton>
@@ -93,7 +93,7 @@
 							:class="{ loading: importingCalendar[cal.id] }"
 							@click="onCalendarImport(cal)">
 							<template #icon>
-								<CalendarIcon />
+								<CalendarImportOutlineIcon />
 							</template>
 							{{ t('integration_google', 'Import calendar') }}
 						</NcButton>
@@ -110,7 +110,7 @@
 					</NcCheckboxRadioSwitch>
 					<div v-if="!importingDrive" class="line">
 						<label for="document-format">
-							<FileDocumentIcon />
+							<FileDocumentOutlineIcon />
 							{{ t('integration_google', 'Google documents import format') }}
 						</label>
 						<select id="document-format"
@@ -127,7 +127,7 @@
 					</div>
 					<div v-if="!importingDrive" class="line">
 						<label for="drive-output">
-							<FolderIcon />
+							<FolderOutlineIcon />
 							{{ t('integration_google', 'Import directory') }}
 						</label>
 						<input id="drive-output"
@@ -136,14 +136,14 @@
 						<NcButton class="edit-output-dir"
 							@click="onDriveOutputChange">
 							<template #icon>
-								<PencilIcon />
+								<PencilOutlineIcon />
 							</template>
 						</NcButton>
 						<br><br>
 					</div>
 					<div class="line">
 						<label v-if="state.consider_shared_files && sharedWithMeSize > 0">
-							<FileIcon />
+							<FileOutlineIcon />
 							{{ t('integration_google',
 								'Your Google Drive ({formSize} + {formSharedSize} shared with you)',
 								{ formSize: myHumanFileSize(driveSize, true), formSharedSize: myHumanFileSize(sharedWithMeSize, true) }
@@ -151,7 +151,7 @@
 							}}
 						</label>
 						<label v-else>
-							<FileIcon />
+							<FileOutlineIcon />
 							{{ t('integration_google', 'Your Google Drive ({formSize})', { formSize: myHumanFileSize(driveSize, true) }) }}
 						</label>
 						<NcButton v-if="enoughSpaceForDrive && !importingDrive"
@@ -189,15 +189,15 @@
 
 <script>
 import CheckIcon from 'vue-material-design-icons/Check.vue'
-import AccountGroupIcon from 'vue-material-design-icons/AccountGroup.vue'
-import FileDocumentIcon from 'vue-material-design-icons/FileDocument.vue'
-import FileIcon from 'vue-material-design-icons/File.vue'
-import FolderIcon from 'vue-material-design-icons/Folder.vue'
+import AccountGroupOutlineIcon from 'vue-material-design-icons/AccountGroupOutline.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import FileOutlineIcon from 'vue-material-design-icons/FileOutline.vue'
+import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
-import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
-import DownloadIcon from 'vue-material-design-icons/Download.vue'
-import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
-import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import CalendarImportOutlineIcon from 'vue-material-design-icons/CalendarImportOutline.vue'
+import DownloadOutlineIcon from 'vue-material-design-icons/DownloadOutline.vue'
+import AccountMultipleOutlineIcon from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import GoogleDriveIcon from 'vue-material-design-icons/GoogleDrive.vue'
 
 import GoogleIcon from './icons/GoogleIcon.vue'
@@ -224,15 +224,15 @@ export default {
 		NcCheckboxRadioSwitch,
 		CloseIcon,
 		GoogleDriveIcon,
-		PencilIcon,
-		AccountMultipleIcon,
-		DownloadIcon,
-		CalendarIcon,
-		FolderIcon,
-		FileDocumentIcon,
-		FileIcon,
+		PencilOutlineIcon,
+		AccountMultipleOutlineIcon,
+		DownloadOutlineIcon,
+		CalendarImportOutlineIcon,
+		FolderOutlineIcon,
+		FileDocumentOutlineIcon,
+		FileOutlineIcon,
 		CheckIcon,
-		AccountGroupIcon,
+		AccountGroupOutlineIcon,
 	},
 
 	props: [],


### PR DESCRIPTION
## Screenshots
<img width="978" height="557" alt="image" src="https://github.com/user-attachments/assets/26f0c33d-5018-4b48-a28c-27cb387e1341" />
<img width="972" height="838" alt="image" src="https://github.com/user-attachments/assets/db703c1c-1e50-4dcf-997c-3cb50460cedc" />

## Some Things Not Sure About
Personally the outlined version of the group icon's don't look very good (specifically the 3 one with 3 people), and also don't know if we want to invert the google icon so it looks like the picture below
<img width="69" height="65" alt="image" src="https://github.com/user-attachments/assets/0a8ac905-567a-4c51-8699-1be7749ba7d1" />
