### PR TITLE
fix: remove url encoding from calendar names

### DIFF
--- a/lib/Service/GoogleCalendarAPIService.php
+++ b/lib/Service/GoogleCalendarAPIService.php
@@ -174,11 +174,13 @@ class GoogleCalendarAPIService {
 			$params['{http://apple.com/ns/ical/}calendar-color'] = $color;
 		}
 
-		$newCalName = urlencode(trim($calName) . ' (' . $this->l10n->t('Google Calendar import') . ')');
+		$newCalName = trim($calName) . ' (' . $this->l10n->t('Google Calendar import') . ')';
+		$params['{DAV:}displayname'] = $newCalName;
+
 		$ncCalId = $this->calendarExists($userId, $newCalName);
 		$calendarIsNew = is_null($ncCalId);
 		if (is_null($ncCalId)) {
-			$ncCalId = $this->caldavBackend->createCalendar('principals/users/' . $userId, $newCalName, $params);
+			$ncCalId = $this->caldavBackend->createCalendar('principals/users/' . $userId, urlencode($newCalName), $params);
 		}
 
 		// get color list


### PR DESCRIPTION
@MarcelRobitaille 

Resolves: #275